### PR TITLE
Remove content-box border sizing to search input type

### DIFF
--- a/less/base/_forms.less
+++ b/less/base/_forms.less
@@ -88,9 +88,6 @@ html input[disabled] { cursor: default; }
 
 input[type="search"] {
   -webkit-appearance: textfield;
-  -moz-box-sizing: content-box;
-  -webkit-box-sizing: content-box;
-  box-sizing: content-box;
 }
 input[type="search"]::-webkit-search-cancel-button, 
 input[type="search"]::-webkit-search-decoration { -webkit-appearance: none; }

--- a/scss/base/_forms.scss
+++ b/scss/base/_forms.scss
@@ -88,9 +88,6 @@ html input[disabled] { cursor: default; }
 
 input[type="search"] {
   -webkit-appearance: textfield;
-  -moz-box-sizing: content-box;
-  -webkit-box-sizing: content-box;
-  box-sizing: content-box;
 }
 input[type="search"]::-webkit-search-cancel-button, 
 input[type="search"]::-webkit-search-decoration { -webkit-appearance: none; }


### PR DESCRIPTION
Removed the content-box box-sizing model since the specified on the root is border-box. This avoids search input elements to overflow when they are supposed to fill 100% of the column width.