### PR TITLE
Fixing Typo

### DIFF
--- a/docs/css.html
+++ b/docs/css.html
@@ -36,7 +36,7 @@
       <div class="left col-8 tablet-col-6 mobile-full mobile-container mobile-text-center">
         <h1 class="h2">Global CSS</h1>
         <p class="font-light col-11 tablet-col-12">
-          Base uses relative sizing (rems, not pixels) for global typography. Sans-serif is the default font family and the global size is 16rem with a line height of 21rem.
+          Base uses relative sizing (rems, not pixels) for global typography. Sans-serif is the default font family and the global size is 1rem with a line height of 1.3125rem.
         </p>
       </div>
       <div id="carbonads-container" class="right mobile-full mobile-container-full carbonads-container"><div class="carbonad mobile-container-full"><div id="azcarbon"></div><script type="text/javascript">var z = document.createElement("script"); z.type = "text/javascript"; z.async = true; z.src = "http://engine.carbonads.com/z/53383/azcarbon_2_1_0_HORIZDARK"; var s = document.getElementsByTagName("script")[0]; s.parentNode.insertBefore(z, s);</script></div></div>


### PR DESCRIPTION
There is a typo in the documentation that states that the default font size is 16rem (which should be 1rem because it meant 16px) and the default line height is 21rem (which should be 1.3125rem because it meant 21 px). Minor, but definitely caught my attention.
