### PR TITLE
small proposed fix for issue #39

### DIFF
--- a/scss/base/_grid.scss
+++ b/scss/base/_grid.scss
@@ -253,8 +253,4 @@
 
 .no-desktop { display: none; }
 
-// Remove Margin / Padding
-.no-margin { margin: 0; }
-.no-padding { padding: 0; }
-
 @import "../_desktop-styles"; // Import Custom Desktop Styles

--- a/scss/base/_helpers.scss
+++ b/scss/base/_helpers.scss
@@ -51,3 +51,7 @@
 // Image Spacing
 .image-left { margin-right: 20px; }
 .image-right { margin-left: 20px; }
+
+// Remove Margin / Padding
+.no-margin { margin: 0; }
+.no-padding { padding: 0; }


### PR DESCRIPTION
I propose to move the the selectors .no-margin and .no-padding into _helper.scss so you don't have to include _grid.scss to compile base without error.