### PR TITLE
Fix for documentation error

### DIFF
--- a/docs/css.html
+++ b/docs/css.html
@@ -815,7 +815,7 @@
         <li class="pad-top-5 pad-bottom-5">
           <div class="clear row-m">
             <div class="col-4-m">
-              <code data-content="variable:">$base-input-background-color-focus</code>
+              <code data-content="variable:">$base-input-background-focus-color</code>
             </div>
             <div class="col-3-m">
               <code data-content="default value:">#fff</code>
@@ -841,7 +841,7 @@
         <li class="pad-top-5 pad-bottom-5">
           <div class="clear row-m">
             <div class="col-4-m">
-              <code data-content="variable:">$base-input-border-color-focus</code>
+              <code data-content="variable:">$base-input-border-focus-color</code>
             </div>
             <div class="col-3-m">
               <code data-content="default value:">#f7c723</code>
@@ -1270,13 +1270,13 @@
       </div>
     </div>
 
-    
-    <h3>Definition List</h3>      
+
+    <h3>Definition List</h3>
     <dl>
       <dt>Definition List</dt>
       <dd>The DL element should be used when you want incorporate a definition of a term in your document, it is often used in glossaries to define many terms, it is also used in “normal” documents when the author wishes to explain a term in a more detail (Like this definition).</dd>
     </dl>
-    
+
     <hr>
 
     <h2 id="blockquotes">Blockquotes</h2>
@@ -1322,7 +1322,7 @@
         </tr>
       </tbody>
     </table>
-    
+
     <hr>
 
     <h2 id="code-blocks">Code blocks</h2>
@@ -1389,13 +1389,13 @@
     <hr>
 
     <p>
-      There is also styling to convert a <code>&lt;button&gt;</code> element to look like a standard link. Simply add the <code>.button-link</code> class to the element to see it in action. 
+      There is also styling to convert a <code>&lt;button&gt;</code> element to look like a standard link. Simply add the <code>.button-link</code> class to the element to see it in action.
     </p>
     <button class="button-link">Button with link styling</button>
 
     <h4 class="fs-6 strong">Code Snippet</h4>
     <pre class="prettyprint lang-html">&lt;button class="button-link"&gt;Button with link styling&lt;/button&gt;</pre>
-    
+
     <hr>
 
     <p>

--- a/src/docs/css.html
+++ b/src/docs/css.html
@@ -815,7 +815,7 @@
         <li class="pad-top-5 pad-bottom-5">
           <div class="clear row-m">
             <div class="col-4-m">
-              <code data-content="variable:">$base-input-background-color-focus</code>
+              <code data-content="variable:">$base-input-background-focus-color</code>
             </div>
             <div class="col-3-m">
               <code data-content="default value:">#fff</code>
@@ -841,7 +841,7 @@
         <li class="pad-top-5 pad-bottom-5">
           <div class="clear row-m">
             <div class="col-4-m">
-              <code data-content="variable:">$base-input-border-color-focus</code>
+              <code data-content="variable:">$base-input-border-focus-color</code>
             </div>
             <div class="col-3-m">
               <code data-content="default value:">#f7c723</code>
@@ -1270,13 +1270,13 @@
       </div>
     </div>
 
-    
-    <h3>Definition List</h3>      
+
+    <h3>Definition List</h3>
     <dl>
       <dt>Definition List</dt>
       <dd>The DL element should be used when you want incorporate a definition of a term in your document, it is often used in glossaries to define many terms, it is also used in “normal” documents when the author wishes to explain a term in a more detail (Like this definition).</dd>
     </dl>
-    
+
     <hr>
 
     <h2 id="blockquotes">Blockquotes</h2>
@@ -1322,7 +1322,7 @@
         </tr>
       </tbody>
     </table>
-    
+
     <hr>
 
     <h2 id="code-blocks">Code blocks</h2>
@@ -1389,13 +1389,13 @@
     <hr>
 
     <p>
-      There is also styling to convert a <code>&lt;button&gt;</code> element to look like a standard link. Simply add the <code>.button-link</code> class to the element to see it in action. 
+      There is also styling to convert a <code>&lt;button&gt;</code> element to look like a standard link. Simply add the <code>.button-link</code> class to the element to see it in action.
     </p>
     <button class="button-link">Button with link styling</button>
 
     <h4 class="fs-6 strong">Code Snippet</h4>
     <pre class="prettyprint lang-html">&lt;button class="button-link"&gt;Button with link styling&lt;/button&gt;</pre>
-    
+
     <hr>
 
     <p>


### PR DESCRIPTION
Discovered a minor typo when working with the package; the documentation used the variables `$base-input-background-color-focus` and `$base-input-border-color-focus` while it say `$base-input-background-focus-color` and `$base-input-border-focus-color`. 